### PR TITLE
Adding grid feature to the space in Pyramid

### DIFF
--- a/src/Pyramid-Bloc/PyramidElementsManipulationHelper.class.st
+++ b/src/Pyramid-Bloc/PyramidElementsManipulationHelper.class.st
@@ -28,10 +28,10 @@ PyramidElementsManipulationHelper class >> accumulateParentsOf: aCollectionOfBlE
 	nextCollection := OrderedCollection new.
 
 	onCollection do: [ :each |
-		(each hasParent: elementToTest) ifFalse: [
+		(each allParentsInclude: elementToTest) ifFalse: [
 			nextCollection add: each ].
-		(shouldKeepIt and: [ elementToTest hasParent: each ]) ifTrue: [
-			shouldKeepIt := false ] ].
+		(shouldKeepIt and: [ elementToTest allParentsInclude: each ])
+			ifTrue: [ shouldKeepIt := false ] ].
 	shouldKeepIt ifTrue: [ result add: elementToTest ].
 	self accumulateParentsOf: nextCollection in: result
 ]

--- a/src/Pyramid-Bloc/PyramidMainExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidMainExtension.class.st
@@ -15,7 +15,7 @@ Class {
 		'gridVisibility',
 		'gridSpacing',
 		'gridColor',
-		'selectionWidgetExtensionPlugin'
+		'selectionWidgetExtension'
 	],
 	#category : #'Pyramid-Bloc-plugin-space-extensions'
 }
@@ -45,9 +45,9 @@ PyramidMainExtension >> createGrid [
 									color: gridColor 
 									width: (gridWindowSize x) 
 									height: (gridWindowSize y).
-									selectionWidgetExtensionPlugin movingLap: self gridSpacing
+									selectionWidgetExtension movingLap: self gridSpacing
 								]
-						ifFalse: [ selectionWidgetExtensionPlugin movingLap: 1 ].
+						ifFalse: [ selectionWidgetExtension movingLap: 1 ].
 	
 	 
 ]
@@ -106,20 +106,19 @@ PyramidMainExtension >> extent: aPoint [
 { #category : #'as yet unclassified' }
 PyramidMainExtension >> getSelectionWidgetExtension: aPyramidEditor [
 
-	| spacePlugin spacePluginList listOfSpaceExtension selectionWidgetExtensionSet selectionWidgetExtension |
+	| spacePlugin spacePluginList listOfSpaceExtension selectionWidgetExtensionSet |
 	
 	spacePluginList := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidSpacePlugin ].
 	spacePluginList size = 1
 	ifFalse: [^ self].
-	spacePluginList do: [ :plug | spacePlugin := plug ].
+	spacePlugin := spacePluginList asArray first.
 	
 	listOfSpaceExtension := spacePlugin builder extensions.
 	selectionWidgetExtensionSet := listOfSpaceExtension select: [ :extensions | extensions isKindOf: PyramidSelectionWidgetExtension ].
 	selectionWidgetExtensionSet size = 1
 	ifFalse: [^ self].
-	selectionWidgetExtensionSet do: [ :extension | selectionWidgetExtension := extension ].
 	
-	selectionWidgetExtensionPlugin := selectionWidgetExtension.
+	selectionWidgetExtension := (selectionWidgetExtensionSet asArray) first
 ]
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid-Bloc/PyramidMainExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidMainExtension.class.st
@@ -26,6 +26,12 @@ PyramidMainExtension >> borderElement [
 	^ borderElement
 ]
 
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> checkZeroOrSubZeroGridSpacingValue: aValue [
+
+	^ aValue < 1
+]
+
 { #category : #accessing }
 PyramidMainExtension >> containerElement [
 
@@ -40,14 +46,14 @@ PyramidMainExtension >> createGrid [
 	self gridElement removeChildWithId: #gridVertical.
 	
 	"Create the grid if gridVisibility is true"
-	gridVisibility ifTrue: [ self grid: gridElement 
-									cellSpacing: gridSpacing 
-									color: gridColor 
-									width: (gridWindowSize x) 
-									height: (gridWindowSize y).
-									selectionWidgetExtension movingLap: self gridSpacing
+	gridVisibility ifTrue: [	self grid: self gridElement 
+									cellSpacing: self gridSpacing 
+									color: self gridColor 
+									width: (self gridWindowSize x) 
+									height: (self gridWindowSize y).
+									self selectionWidgetExtension movingLap: self gridSpacing
 								]
-						ifFalse: [ selectionWidgetExtension movingLap: 1 ].
+						ifFalse: [ self selectionWidgetExtension movingLap: 1 ].
 	
 	 
 ]
@@ -175,6 +181,12 @@ PyramidMainExtension >> grid: aParent cellSpacing: aNumber color: aColor width: 
 			elementGridVertical }
 ]
 
+{ #category : #accessing }
+PyramidMainExtension >> gridColor [
+
+	^ gridColor
+]
+
 { #category : #'as yet unclassified' }
 PyramidMainExtension >> gridDefaultValueInitializer [
 	
@@ -220,40 +232,51 @@ PyramidMainExtension >> informTransformationChanged [
 
 { #category : #initialization }
 PyramidMainExtension >> initialize [
-	
 	"Set the default parameter value of the grid"
+
 	gridWindowSize := self defaultExtent.
 	gridVisibility := self defaultGridVisibility.
 	gridSpacing := self defaultGridSpacing.
 	gridColor := self defaultGridColor.
-	
+
 	"Set up the graphical parameter windows of the grid and the space extension"
 	workplacePropertiesView := PyramidWorkplacePropertiesPresenter new
-									workplaceSizeValue: self defaultExtent;
-									whenWorkplaceValuesChangedDo: [ :point | 
-																		self extent: point ];	
-									whenVisibilityChangedDo: [ self switchGridvisibility. 
-																		self createGrid ];
-									spacingTextValue: self defaultGridSpacing;
-									whenSpacingTextChangedDo: [ :value | 
-																		gridSpacing := value. self createGrid ];
-									gridColorValue: self defaultGridColor;
-									whenColorValuesChangedDo: [ :color | 
-																		gridColor := color. self createGrid ];
-									yourself.
-	
+		                           workplaceSizeValue: self defaultExtent;
+		                           whenWorkplaceValuesChangedDo: [ :point |
+												self extent: point ];
+		                           whenVisibilityChangedDo: [
+												self switchGridvisibility.
+												self createGrid ];
+		                           spacingTextValue: self defaultGridSpacing;
+		                           whenSpacingTextChangedDo: [ :value | 
+												(self checkZeroOrSubZeroGridSpacingValue: value)
+												ifTrue: [ gridSpacing := 1. self workplacePropertiesView spacingTextValue: 1 ]
+												ifFalse: [ gridSpacing := value ].
+												self createGrid ];
+		                           gridColorValue: self defaultGridColor;
+		                           whenColorValuesChangedDo: [ :color |
+												gridColor := color.
+												self createGrid ];
+		                           yourself.
+
 	"Button of the pop-up windows properties who call the creation of the pop-up"
 	workplacePropertiesButton := SpButtonPresenter new
-		                icon: (Smalltalk ui icons iconNamed: #window);
-		                help: 'Edit the properties of the workplace';
-		                action: [ workplacePropertiesPopover popup. self refreshPopupWorkplaceProperties ];
-		                yourself.
-	
+		                             icon:
+			                             (Smalltalk ui icons iconNamed: #window);
+		                             help:
+			                             'Edit the properties of the workplace';
+		                             action: [
+			                             self workplacePropertiesPopover popup.
+			                             self refreshPopupWorkplaceProperties ];
+		                             yourself.
+
 	"Creation of the pop-up"
 	workplacePropertiesPopover := PyramidPopoverFactory
-		                 makeWithPresenter: workplacePropertiesView
-		                 relativeTo: workplacePropertiesButton
-		                 position: SpPopoverPosition left.
+		                              makeWithPresenter:
+		                              self workplacePropertiesView
+		                              relativeTo:
+		                              self workplacePropertiesButton
+		                              position: SpPopoverPosition left.
 
 	containerElement := BlElement new
 		                    id: #MainExtension_containerElement;
@@ -263,7 +286,7 @@ PyramidMainExtension >> initialize [
 		                    clipChildren: false;
 		                    zIndex: 0;
 		                    yourself.
-	
+
 	"Blue frame in the space"
 	borderElement := BlElement new
 		                 id: #MainExtension_borderElement;
@@ -274,17 +297,17 @@ PyramidMainExtension >> initialize [
 			                 c horizontal matchParent ];
 		                 clipChildren: false;
 		                 zIndex: 1;
-								preventMeAndChildrenMouseEvents;
-		                 yourself. 
-	
+		                 preventMeAndChildrenMouseEvents;
+		                 yourself.
+
 	"The BlElement contain the grid"
 	gridElement := BlElement new
-							id: #MainExtension_gridElement;
-							constraintsDo: [ :c |
-								c vertical matchParent.
-								c horizontal matchParent ];
-							zIndex: 0.
-	
+		               id: #MainExtension_gridElement;
+		               constraintsDo: [ :c |
+			               c vertical matchParent.
+			               c horizontal matchParent ];
+		               zIndex: 0.
+
 	sizeElement := BlElement new
 		               id: #MainExtension_sizeElement;
 		               size: self defaultExtent;
@@ -292,9 +315,7 @@ PyramidMainExtension >> initialize [
 		               addChildren: {
 				               containerElement.
 				               borderElement.
-									gridElement
-											 } yourself.
-	
+				               gridElement } yourself
 ]
 
 { #category : #displaying }
@@ -345,6 +366,12 @@ PyramidMainExtension >> refreshPopupWorkplaceProperties [
 ]
 
 { #category : #accessing }
+PyramidMainExtension >> selectionWidgetExtension [
+
+	^ selectionWidgetExtension
+]
+
+{ #category : #accessing }
 PyramidMainExtension >> sizeElement [
 
 	^ sizeElement
@@ -362,6 +389,12 @@ PyramidMainExtension >> switchGridvisibility [
 PyramidMainExtension >> workplacePropertiesButton [
 
 	^ workplacePropertiesButton
+]
+
+{ #category : #accessing }
+PyramidMainExtension >> workplacePropertiesPopover [
+
+	^ workplacePropertiesPopover
 ]
 
 { #category : #accessing }

--- a/src/Pyramid-Bloc/PyramidMainExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidMainExtension.class.st
@@ -7,9 +7,15 @@ Class {
 		'containerElement',
 		'borderElement',
 		'sizeElement',
-		'extentButton',
-		'extentView',
-		'extentPopover'
+		'workplacePropertiesButton',
+		'workplacePropertiesView',
+		'workplacePropertiesPopover',
+		'gridWindowSize',
+		'gridElement',
+		'gridVisibility',
+		'gridSpacing',
+		'gridColor',
+		'selectionWidgetExtensionPlugin'
 	],
 	#category : #'Pyramid-Bloc-plugin-space-extensions'
 }
@@ -26,6 +32,26 @@ PyramidMainExtension >> containerElement [
 	^ containerElement
 ]
 
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> createGrid [
+	
+	"Remove the current all the line of the grid"
+	self gridElement removeChildWithId: #gridHorizontal.
+	self gridElement removeChildWithId: #gridVertical.
+	
+	"Create the grid if gridVisibility is true"
+	gridVisibility ifTrue: [ self grid: gridElement 
+									cellSpacing: gridSpacing 
+									color: gridColor 
+									width: (gridWindowSize x) 
+									height: (gridWindowSize y).
+									selectionWidgetExtensionPlugin movingLap: self gridSpacing
+								]
+						ifFalse: [ selectionWidgetExtensionPlugin movingLap: 1 ].
+	
+	 
+]
+
 { #category : #accessing }
 PyramidMainExtension >> defaultBorder [
 
@@ -38,24 +64,152 @@ PyramidMainExtension >> defaultExtent [
 	^ 800 @ 600
 ]
 
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> defaultGridColor [
+	"Default color value of the grid"
+	^ Color black
+]
+
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> defaultGridSpacing [
+	"Default spacing value of the grid"
+	^ 10
+]
+
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> defaultGridVisibility [
+	"Default visibility value of the grid"
+	^ false
+]
+
 { #category : #accessing }
 PyramidMainExtension >> editor: aPyramidEditor [
 
 	aPyramidEditor window at: #topRight addItem: [ :buttonBuilder |
-		buttonBuilder makeButtonWithIcon: self extentButton order: 10 ]
+		buttonBuilder makeButtonWithIcon: self workplacePropertiesButton order: 10 ].
+	
+	self getSelectionWidgetExtension: aPyramidEditor.
 ]
 
 { #category : #geometry }
 PyramidMainExtension >> extent: aPoint [
 
 	self elementAtWidgets size: aPoint.
-	self sizeElement size: aPoint
+	self sizeElement size: aPoint.
+	self gridWindowSize: aPoint.
+	
+	self createGrid.
+	
+
+]
+
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> getSelectionWidgetExtension: aPyramidEditor [
+
+	| spacePlugin spacePluginList listOfSpaceExtension selectionWidgetExtensionSet selectionWidgetExtension |
+	
+	spacePluginList := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidSpacePlugin ].
+	spacePluginList size = 1
+	ifFalse: [^ self].
+	spacePluginList do: [ :plug | spacePlugin := plug ].
+	
+	listOfSpaceExtension := spacePlugin builder extensions.
+	selectionWidgetExtensionSet := listOfSpaceExtension select: [ :extensions | extensions isKindOf: PyramidSelectionWidgetExtension ].
+	selectionWidgetExtensionSet size = 1
+	ifFalse: [^ self].
+	selectionWidgetExtensionSet do: [ :extension | selectionWidgetExtension := extension ].
+	
+	selectionWidgetExtensionPlugin := selectionWidgetExtension.
+]
+
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> grid: aParent cellSpacing: aNumber color: aColor width: aWidth height: aHeight [
+	
+	"Creation of the grid used by createGrid"
+	| elementGridHorizontal elementGridVertical nbLineGridHorizontal nbLineGridVertical lineGridModWidth lineGridModHeight |
+	
+	elementGridHorizontal := BlElement new id: #gridHorizontal.
+	elementGridHorizontal layout: BlLinearLayout vertical.
+	elementGridHorizontal layout cellSpacing: (aNumber - 1).
+	elementGridHorizontal constraints horizontal matchParent.
+	elementGridHorizontal constraints vertical matchParent.
+
+	elementGridVertical := BlElement new id: #gridVertical.
+	elementGridVertical layout: BlLinearLayout horizontal.
+	elementGridVertical layout cellSpacing: aNumber - 1.
+	elementGridVertical constraints horizontal matchParent.
+	elementGridVertical constraints vertical matchParent.
+
+	"Number of line Horizontal"
+	lineGridModHeight := aHeight / aNumber.
+	nbLineGridHorizontal := lineGridModHeight isInteger
+		                      ifTrue: [ aHeight / aNumber - 1 ]
+		                      ifFalse: [ aHeight / aNumber ].
+
+	1 to: nbLineGridHorizontal do: [ :i |
+		| e |
+		e := BlElement new.
+		e background: aColor.
+		e border: aColor.
+		e height: 1.
+		e constraints horizontal matchParent.
+		elementGridHorizontal addChild: e ].
+
+	"Number of line Vertical"
+	lineGridModWidth := aWidth / aNumber.
+	nbLineGridVertical := lineGridModWidth isInteger
+		                      ifTrue: [ aWidth / aNumber - 1 ]
+		                      ifFalse: [ aWidth / aNumber ].
+
+
+	1 to: nbLineGridVertical do: [ :i |
+		| e |
+		e := BlElement new.
+		e background: aColor.
+		e border: aColor.
+		e width: 1.
+		e constraints vertical matchParent.
+		elementGridVertical addChild: e ].
+
+	aParent addChildren: {
+			elementGridHorizontal.
+			elementGridVertical }
+]
+
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> gridDefaultValueInitializer [
+	
+	"Set the default parameter values of the grid"
+	gridWindowSize := self defaultExtent.
+	gridVisibility := self defaultGridVisibility.
+	gridSpacing := self defaultGridSpacing.
+	gridColor := self defaultGridColor.
+	self createGrid.
 ]
 
 { #category : #accessing }
-PyramidMainExtension >> extentButton [
+PyramidMainExtension >> gridElement [ 
+	^ gridElement 
+]
 
-	^ extentButton
+{ #category : #accessing }
+PyramidMainExtension >> gridSpacing [
+	^ gridSpacing
+]
+
+{ #category : #accessing }
+PyramidMainExtension >> gridVisibility [
+	^ gridVisibility 
+]
+
+{ #category : #accessing }
+PyramidMainExtension >> gridWindowSize [
+	^ gridWindowSize
+]
+
+{ #category : #accessing }
+PyramidMainExtension >> gridWindowSize: aPoint [
+	gridWindowSize := aPoint
 ]
 
 { #category : #'as yet unclassified' }
@@ -67,32 +221,40 @@ PyramidMainExtension >> informTransformationChanged [
 
 { #category : #initialization }
 PyramidMainExtension >> initialize [
-
-	extentView := SpPresenter new
-		              layout: (SpBoxLayout newVertical
-				               spacing: 4;
-				               add: (SpLabelPresenter new
-						                displayBold: [ true ];
-						                label: 'Window extent';
-						                yourself);
-				               add: (PyramidPointInputPresenter new
-						                value: self defaultExtent;
-						                whenValueChangedDo: [ :point |
-							                self extent: point ];
-						                yourself);
-				               yourself);
-		              yourself.
-
-	extentButton := SpButtonPresenter new
+	
+	"Set the default parameter value of the grid"
+	gridWindowSize := self defaultExtent.
+	gridVisibility := self defaultGridVisibility.
+	gridSpacing := self defaultGridSpacing.
+	gridColor := self defaultGridColor.
+	
+	"Set up the graphical parameter windows of the grid and the space extension"
+	workplacePropertiesView := PyramidWorkplacePropertiesPresenter new
+									workplaceSizeValue: self defaultExtent;
+									whenWorkplaceValuesChangedDo: [ :point | 
+																		self extent: point ];	
+									whenVisibilityChangedDo: [ self switchGridvisibility. 
+																		self createGrid ];
+									spacingTextValue: self defaultGridSpacing;
+									whenSpacingTextChangedDo: [ :value | 
+																		gridSpacing := value. self createGrid ];
+									gridColorValue: self defaultGridColor;
+									whenColorValuesChangedDo: [ :color | 
+																		gridColor := color. self createGrid ];
+									yourself.
+	
+	"Button of the pop-up windows properties who call the creation of the pop-up"
+	workplacePropertiesButton := SpButtonPresenter new
 		                icon: (Smalltalk ui icons iconNamed: #window);
-		                help: 'Project configuration';
-		                action: [ extentPopover popup ];
+		                help: 'Edit the properties of the workplace';
+		                action: [ workplacePropertiesPopover popup. self refreshPopupWorkplaceProperties ];
 		                yourself.
-	extentPopover := PyramidPopoverFactory
-		                 makeWithPresenter: extentView
-		                 relativeTo: extentButton
+	
+	"Creation of the pop-up"
+	workplacePropertiesPopover := PyramidPopoverFactory
+		                 makeWithPresenter: workplacePropertiesView
+		                 relativeTo: workplacePropertiesButton
 		                 position: SpPopoverPosition left.
-
 
 	containerElement := BlElement new
 		                    id: #MainExtension_containerElement;
@@ -102,6 +264,8 @@ PyramidMainExtension >> initialize [
 		                    clipChildren: false;
 		                    zIndex: 0;
 		                    yourself.
+	
+	"Blue frame in the space"
 	borderElement := BlElement new
 		                 id: #MainExtension_borderElement;
 		                 border: self defaultBorder;
@@ -112,14 +276,26 @@ PyramidMainExtension >> initialize [
 		                 clipChildren: false;
 		                 zIndex: 1;
 								preventMeAndChildrenMouseEvents;
-		                 yourself.
+		                 yourself. 
+	
+	"The BlElement contain the grid"
+	gridElement := BlElement new
+							id: #MainExtension_gridElement;
+							constraintsDo: [ :c |
+								c vertical matchParent.
+								c horizontal matchParent ];
+							zIndex: 0.
+	
 	sizeElement := BlElement new
 		               id: #MainExtension_sizeElement;
 		               size: self defaultExtent;
 		               clipChildren: false;
 		               addChildren: {
 				               containerElement.
-				               borderElement } yourself
+				               borderElement.
+									gridElement
+											 } yourself.
+	
 ]
 
 { #category : #displaying }
@@ -159,8 +335,38 @@ PyramidMainExtension >> pyramidFirstLevelElementsChanged: anEvent [
 		self containerElement addChild: each ]
 ]
 
+{ #category : #refresh }
+PyramidMainExtension >> refreshPopupWorkplaceProperties [
+
+	"Fix the current bug of the pop-up grow after each opening by recreating the component pop-up each time"
+	workplacePropertiesPopover := PyramidPopoverFactory
+		                 makeWithPresenter: workplacePropertiesView
+		                 relativeTo: workplacePropertiesButton
+		                 position: SpPopoverPosition left.
+]
+
 { #category : #accessing }
 PyramidMainExtension >> sizeElement [
 
 	^ sizeElement
+]
+
+{ #category : #'as yet unclassified' }
+PyramidMainExtension >> switchGridvisibility [
+	"Switch the visibility from true to false or false to true"
+	gridVisibility := self gridVisibility not.
+	
+	^ self gridVisibility
+]
+
+{ #category : #accessing }
+PyramidMainExtension >> workplacePropertiesButton [
+
+	^ workplacePropertiesButton
+]
+
+{ #category : #accessing }
+PyramidMainExtension >> workplacePropertiesView [
+
+	^ workplacePropertiesView
 ]

--- a/src/Pyramid-Bloc/PyramidMainExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidMainExtension.class.st
@@ -250,7 +250,7 @@ PyramidMainExtension >> initialize [
 		                           spacingTextValue: self defaultGridSpacing;
 		                           whenSpacingTextChangedDo: [ :value | 
 												(self checkZeroOrSubZeroGridSpacingValue: value)
-												ifTrue: [ gridSpacing := 1. self workplacePropertiesView spacingTextValue: 1 ]
+												ifTrue: [ gridSpacing := self defaultGridSpacing ]
 												ifFalse: [ gridSpacing := value ].
 												self createGrid ];
 		                           gridColorValue: self defaultGridColor;

--- a/src/Pyramid-Bloc/PyramidSelectionMakerExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidSelectionMakerExtension.class.st
@@ -66,7 +66,7 @@ PyramidSelectionMakerExtension >> dragEnd: anEvent [
 { #category : #'event handling' }
 PyramidSelectionMakerExtension >> dragEvent: anEvent [
 
-	| xmin ymin |
+	| xmin ymin "newY newX" |
 	self isDragging ifFalse: [ ^ self ].
 	(anEvent primaryButtonPressed or: [ anEvent secondaryButtonPressed ])
 		ifFalse: [
@@ -75,6 +75,7 @@ PyramidSelectionMakerExtension >> dragEvent: anEvent [
 
 	xmin := self dragOrigin x min: anEvent position x.
 	ymin := self dragOrigin y min: anEvent position y.
+	
 	self selectionGhost
 		position: xmin @ ymin;
 		size: (anEvent position - self dragOrigin) abs

--- a/src/Pyramid-Bloc/PyramidSelectionWidgetExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidSelectionWidgetExtension.class.st
@@ -18,18 +18,8 @@ Class {
 
 { #category : #'as yet unclassified' }
 PyramidSelectionWidgetExtension >> additionPoint: aPoint1 with: aPoint2 [
-
-	| x1 x2 y1 y2 x y |
-	x1 := aPoint1 x.
-	y1 := aPoint1 y.
 	
-	x2 := aPoint2 x.
-	y2 := aPoint2 y.
-	
-	x := x1 + x2.
-	y := y1 + y2.
-	
-	^x@y
+	^ (aPoint1 x + aPoint2 x) @ (aPoint1 y + aPoint2 y)
 	
 ]
 

--- a/src/Pyramid-Bloc/PyramidSelectionWidgetExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidSelectionWidgetExtension.class.st
@@ -8,10 +8,30 @@ Class {
 		'widgetElement',
 		'commandExecutor',
 		'isDragging',
-		'dragOrigin'
+		'dragOrigin',
+		'movingLap',
+		'childCurrentTranslation',
+		'movingForGrid'
 	],
 	#category : #'Pyramid-Bloc-plugin-space-extensions'
 }
+
+{ #category : #'as yet unclassified' }
+PyramidSelectionWidgetExtension >> additionPoint: aPoint1 with: aPoint2 [
+
+	| x1 x2 y1 y2 x y |
+	x1 := aPoint1 x.
+	y1 := aPoint1 y.
+	
+	x2 := aPoint2 x.
+	y2 := aPoint2 y.
+	
+	x := x1 + x2.
+	y := y1 + y2.
+	
+	^x@y
+	
+]
 
 { #category : #'as yet unclassified' }
 PyramidSelectionWidgetExtension >> alphaFactor [
@@ -22,14 +42,15 @@ PyramidSelectionWidgetExtension >> alphaFactor [
 { #category : #'as yet unclassified' }
 PyramidSelectionWidgetExtension >> centerDragEnd: anEvent [
 
-	anEvent consumed: true.
+	
 	self isDragging: false.
-	self usePositionOffsetCommand: anEvent position - self dragOrigin.
+	self usePositionOffsetCommand: self childCurrentTranslation - movingForGrid.
+	anEvent consumed: true.
 	self widgetElement transformDo: [ :t | t translateBy: 0 @ 0 ].
 	self widgetElement childrenDo: [ :child |
-		child
+		child 
 			childWithId: #drag_ghost
-			ifFound: [ :ghost | ghost visibility: BlVisibility hidden ] ]
+			ifFound: [ :ghost | ghost visibility: BlVisibility hidden. ] ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -39,21 +60,45 @@ PyramidSelectionWidgetExtension >> centerDragEvent: anEvent [
 	anEvent primaryButtonPressed ifFalse: [
 		self centerDragEnd: anEvent.
 		^ self ].
+	self childCurrentTranslation: ((((anEvent position - self dragOrigin)/movingLap)rounded) * movingLap).
 	self widgetElement transformDo: [ :t |
-		t translateBy: anEvent position - self dragOrigin ].
+		"Move the dragged and selected element with the lap of the grid spacing"
+		t translateBy: self childCurrentTranslation ].
 	anEvent consumed: true
 ]
 
 { #category : #'as yet unclassified' }
 PyramidSelectionWidgetExtension >> centerDragStart: anEvent [
-
+	
+	| firstSelected currentPos | 
+	
 	self isDragging: true.
 	self dragOrigin: anEvent position.
 	anEvent consumed: true.
+	
+	"Get the repositionning of the first selected element when the grid is active"
+	firstSelected := self widgetElement children at:1.
+	currentPos := firstSelected position.
+	self movingForGrid: (currentPos - (((firstSelected position/movingLap)rounded)*movingLap)).
+
 	self widgetElement childrenDo: [ :child |
+		"Put the reposition of the first selected element to all selected element"
+		child position: (child position - movingForGrid).
 		child
 			childWithId: #drag_ghost
-			ifFound: [ :ghost | ghost visibility: BlVisibility visible ] ]
+			ifFound: [ :ghost | ghost visibility: BlVisibility visible ] ].
+]
+
+{ #category : #accessing }
+PyramidSelectionWidgetExtension >> childCurrentTranslation [
+
+	^ childCurrentTranslation
+]
+
+{ #category : #accessing }
+PyramidSelectionWidgetExtension >> childCurrentTranslation: aPoint [
+
+	childCurrentTranslation := aPoint
 ]
 
 { #category : #accessing }
@@ -101,7 +146,8 @@ PyramidSelectionWidgetExtension >> initialize [
 		                 zIndex: 1;
 		                 yourself.
 	dragOrigin := 0 @ 0.
-	isDragging := false
+	isDragging := false.
+	movingLap := 1.
 ]
 
 { #category : #displaying }
@@ -177,6 +223,18 @@ PyramidSelectionWidgetExtension >> makeNewSelection [
 	]
 ]
 
+{ #category : #accessing }
+PyramidSelectionWidgetExtension >> movingForGrid: aPoint [
+
+	movingForGrid := aPoint
+]
+
+{ #category : #accessing }
+PyramidSelectionWidgetExtension >> movingLap: aLap [
+
+	movingLap := aLap.
+]
+
 { #category : #'as yet unclassified' }
 PyramidSelectionWidgetExtension >> offset [
 	^ 10
@@ -197,6 +255,7 @@ PyramidSelectionWidgetExtension >> projectModel: aProjectModel [
 		do: [ :evt | self pyramidSelectionChanged: evt ]
 		for: self.
 	self makeNewSelection
+	
 ]
 
 { #category : #events }

--- a/src/Pyramid-Bloc/PyramidSpacePlugin.class.st
+++ b/src/Pyramid-Bloc/PyramidSpacePlugin.class.st
@@ -36,7 +36,7 @@ PyramidSpacePlugin >> connectOn: aPyramidEditor [
 
 { #category : #initialization }
 PyramidSpacePlugin >> initialize [
-
+	
 	builder := PyramidSpaceBuilder defaultEditorBuilder.
 	morphicPresenter := SpMorphPresenter new.
 	resetSpaceButton := SpButtonPresenter new

--- a/src/Pyramid-Bloc/PyramidWorkplacePropertiesPresenter.class.st
+++ b/src/Pyramid-Bloc/PyramidWorkplacePropertiesPresenter.class.st
@@ -115,7 +115,7 @@ PyramidWorkplacePropertiesPresenter >> initializePresenter [
 						yourself.
 	
 	spacingLabel := (SpLabelPresenter new label: 'Spacing :'; yourself).
-	spacingText := PyramidNumberInputPresenter new.
+	spacingText := "PyramidNumberInputPresenter"PyramidNumberFilterOnlyDigitsInputPresenter new.
 						
 	gridColorLabel := (SpLabelPresenter new label: 'Color :'; yourself).
 	gridColor := PyramidColorInputSingleLineWithPickupButtonPresenter new.
@@ -137,7 +137,8 @@ PyramidWorkplacePropertiesPresenter >> spacingTextValue [
 { #category : #'as yet unclassified' }
 PyramidWorkplacePropertiesPresenter >> spacingTextValue: aValue [
 	
-	spacingText value: aValue
+	self spacingText value: aValue.
+	self spacingText defaultValue: aValue
 ]
 
 { #category : #accessing }

--- a/src/Pyramid-Bloc/PyramidWorkplacePropertiesPresenter.class.st
+++ b/src/Pyramid-Bloc/PyramidWorkplacePropertiesPresenter.class.st
@@ -1,0 +1,182 @@
+"
+Workplace properties
+
+This plugin windows use the plugin-space-extension -> PyramidMainExtension
+"
+Class {
+	#name : #PyramidWorkplacePropertiesPresenter,
+	#superclass : #SpPresenter,
+	#instVars : [
+		'gridLabel',
+		'windowTitle',
+		'workplaceSize',
+		'extentWindow',
+		'visibilityButton',
+		'visibilityLabel',
+		'spacingLabel',
+		'spacingText',
+		'gridColorLabel',
+		'gridColor'
+	],
+	#category : #'Pyramid-Bloc-plugin-workplace-properties'
+}
+
+{ #category : #'initialization - deprecated' }
+PyramidWorkplacePropertiesPresenter >> defaultLayout [ 
+
+	| defaultLayout workPlaceSizeLine gridLabelLayout visibilityLine spacingLine colorLine workPlaceTitleLine nothing |
+	defaultLayout := SpBoxLayout newVertical spacing: 6; yourself.
+	
+	"Help to center component on the window"
+	nothing := SpBoxLayout newVertical vAlignCenter; yourself.
+	
+	workPlaceTitleLine:= SpBoxLayout newHorizontal hAlignCenter; yourself.
+	workPlaceTitleLine add: nothing width: 65.
+	workPlaceTitleLine add: windowTitle width: 185.
+	
+	workPlaceSizeLine := SpBoxLayout newVertical.
+	workPlaceSizeLine add: workplaceSize.
+	
+	gridLabelLayout := SpBoxLayout newHorizontal vAlignCenter hAlignCenter; yourself.
+	gridLabelLayout add: gridLabel.
+	
+	visibilityLine := SpBoxLayout newHorizontal vAlignCenter; yourself.
+	
+	visibilityLine add: visibilityLabel.
+	visibilityLine add: visibilityButton width: 15.
+	visibilityLine add: nothing width: 137.
+	
+	spacingLine := SpBoxLayout newHorizontal vAlignCenter; yourself.
+	
+	spacingLine add: spacingLabel.
+	spacingLine add: spacingText.
+	spacingLine add: nothing width: 110.
+	
+	colorLine := SpBoxLayout newHorizontal vAlignCenter; yourself.
+	colorLine add: gridColorLabel.
+	colorLine add: gridColor.
+	
+	defaultLayout add: workPlaceTitleLine expand: false.
+	defaultLayout add: workPlaceSizeLine expand: false.
+	defaultLayout add: gridLabelLayout expand: false.
+	defaultLayout add: visibilityLine expand: false.
+	defaultLayout add: spacingLine expand: false.
+	defaultLayout add: colorLine expand: false.
+	
+	^ defaultLayout
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> extentWindow [
+	^ extentWindow
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> extentWindow: aPoint [
+	extentWindow := aPoint
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> gridColor [
+	^ gridColor
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> gridColorValue [
+	"get the color choose by the user"
+	^ self gridColor value
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> gridColorValue: aColorValue [
+	"set the color choose by the user"
+	self gridColor value: aColorValue 
+]
+
+{ #category : #'initialization - deprecated' }
+PyramidWorkplacePropertiesPresenter >> initializePresenter [ 
+	
+	windowTitle := SpLabelPresenter new 
+							displayBold: [ true ];
+							label: 'Workplace properties';
+							yourself.
+						
+	workplaceSize := PyramidPointInputPresenter new.
+	
+	gridLabel := SpLabelPresenter new 
+							displayBold: [ true ];
+							label: 'Grid';
+							centered;
+							yourself.
+	
+	visibilityLabel := (SpLabelPresenter new label: 'Visibility :'; yourself).
+	visibilityButton := SpCheckBoxPresenter new 
+						help: 'Enable/disable the grid';
+						yourself.
+	
+	spacingLabel := (SpLabelPresenter new label: 'Spacing :'; yourself).
+	spacingText := PyramidNumberInputPresenter new.
+						
+	gridColorLabel := (SpLabelPresenter new label: 'Color :'; yourself).
+	gridColor := PyramidColorInputSingleLineWithPickupButtonPresenter new.
+	
+	
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> spacingText [
+	^ spacingText
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> spacingTextValue [
+	"Spacing value"
+	^ self spacingText value
+]
+
+{ #category : #'as yet unclassified' }
+PyramidWorkplacePropertiesPresenter >> spacingTextValue: aValue [
+	
+	spacingText value: aValue
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> visibilityButton [
+	^ visibilityButton
+]
+
+{ #category : #enumerating }
+PyramidWorkplacePropertiesPresenter >> whenColorValuesChangedDo: aBlock [
+
+	^ gridColor whenValueChangedDo: aBlock
+]
+
+{ #category : #enumerating }
+PyramidWorkplacePropertiesPresenter >> whenSpacingTextChangedDo: aBlock [
+	
+	spacingText whenValueChangedDo: aBlock
+]
+
+{ #category : #enumerating }
+PyramidWorkplacePropertiesPresenter >> whenVisibilityChangedDo: aBlock [
+
+	visibilityButton whenChangedDo: aBlock
+]
+
+{ #category : #enumerating }
+PyramidWorkplacePropertiesPresenter >> whenWorkplaceValuesChangedDo: aBlock [
+
+	workplaceSize whenValueChangedDo: aBlock
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> workplaceSize [
+	"window size component"
+	^ workplaceSize
+]
+
+{ #category : #accessing }
+PyramidWorkplacePropertiesPresenter >> workplaceSizeValue: aPoint [
+	
+	workplaceSize value: aPoint
+]

--- a/src/Pyramid-Tests/PyramidLayoutBlocCommandTest.class.st
+++ b/src/Pyramid-Tests/PyramidLayoutBlocCommandTest.class.st
@@ -14,26 +14,85 @@ PyramidLayoutBlocCommandTest >> command [
 
 { #category : #'as yet unclassified' }
 PyramidLayoutBlocCommandTest >> targetContainers [
-
+	| flowLayoutVertical basicLayout proportionalLayout  |
+	
+	flowLayoutVertical := BlFlowLayout vertical.
+	basicLayout := BlBasicLayout new.
+	proportionalLayout := BlProportionalLayout new.
+	
 	^ {
 		  (PyramidCommandTestContainer
 			   no: BlElement new
 			   with: (BlElement new
-					    layout: BlFlowLayout vertical;
+					    layout: flowLayoutVertical;
 					    yourself)
-			   prop: BlFlowLayout vertical).
+			   prop: flowLayoutVertical).
 		  (PyramidCommandTestContainer
 			   no: (BlElement new
-					    layout: BlFlowLayout vertical;
+					    layout: flowLayoutVertical;
 					    yourself)
 			   with: (BlElement new
-					    layout: BlBasicLayout new;
+					    layout: basicLayout;
 					    yourself)
-			   prop: BlBasicLayout new).
+			   prop: basicLayout).
 		  (PyramidCommandTestContainer
 			   no: BlElement new
 			   with: (BlElement new
-					    layout: BlProportionalLayout new;
+					    layout: proportionalLayout;
 					    yourself)
-			   prop: BlProportionalLayout new) }
+			   prop: proportionalLayout) }
+]
+
+{ #category : #'as yet unclassified' }
+PyramidLayoutBlocCommandTest >> targetsCanBeUsedFor [
+
+	"^ self targetContainers flatCollect: [ :each | { each targetNoProp . each targetWithProp } ]."
+	^ self targetContainers collect: [ :each | each targetNoProp  ].
+]
+
+{ #category : #tests }
+PyramidLayoutBlocCommandTest >> testHistory [
+	"Do once.
+	undo
+	redo
+	undo
+	redo"
+
+	| history commandExecutor targets |
+	targets := self targetsCanBeUsedFor.
+	history := PyramidHistory new.
+	commandExecutor := PyramidHistoryCommandExecutor new
+		                   history: history;
+		                   wrappee: PyramidMainCommandExecutor new;
+		                   yourself.
+
+	"Do once"
+	self argumentsForHistory do: [ :each |
+		commandExecutor use: self command on: targets with: each ].
+
+	"Undo all"
+	self argumentsForHistory reverseDo: [ :argument |
+		targets do: [ :target |
+			self
+				assert: (self command getValueFor: target) class
+				equals: argument class ].
+		history canUndo ifTrue: [ history undo ] ].
+
+	"Redo all"
+	self argumentsForHistory do: [ :argument |
+		history canRedo ifTrue: [ history redo ].
+		targets do: [ :target |
+			self assert: (self command getValueFor: target) class equals: argument class] ].
+
+	"Undo all"
+	self argumentsForHistory reverseDo: [ :argument |
+		targets do: [ :target |
+			self assert: (self command getValueFor: target) class equals: argument class].
+		history canUndo ifTrue: [ history undo ] ].
+
+	"Redo all"
+	self argumentsForHistory do: [ :argument |
+		history canRedo ifTrue: [ history redo ].
+		targets do: [ :target |
+			self assert: (self command getValueFor: target) class equals: argument class ] ]
 ]

--- a/src/Pyramid/PyramidAbstractMemento.class.st
+++ b/src/Pyramid/PyramidAbstractMemento.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidAbstractMemento,
 	#superclass : #Object,
-	#category : 'Pyramid-history'
+	#category : #'Pyramid-history'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidAddAllToCollectionCommand.class.st
+++ b/src/Pyramid/PyramidAddAllToCollectionCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidAddAllToCollectionCommand,
 	#superclass : #PyramidCollectionCommand,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidAddToCollectionCommand.class.st
+++ b/src/Pyramid/PyramidAddToCollectionCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidAddToCollectionCommand,
 	#superclass : #PyramidCollectionCommand,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidCallbackCommandExecutor.class.st
+++ b/src/Pyramid/PyramidCallbackCommandExecutor.class.st
@@ -5,7 +5,7 @@ Class {
 		'beforeDo',
 		'afterDo'
 	],
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidCluster.class.st
+++ b/src/Pyramid/PyramidCluster.class.st
@@ -7,7 +7,7 @@ Class {
 		'groupedAssociations',
 		'individualAssociations'
 	],
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidCollectionCommand.class.st
+++ b/src/Pyramid/PyramidCollectionCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidCollectionCommand,
 	#superclass : #PyramidCommand,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidCollectionWithCallbacks.class.st
+++ b/src/Pyramid/PyramidCollectionWithCallbacks.class.st
@@ -5,7 +5,7 @@ Class {
 		'collection',
 		'subscriptions'
 	],
-	#category : 'Pyramid-models'
+	#category : #'Pyramid-models'
 }
 
 { #category : #adding }

--- a/src/Pyramid/PyramidColorInputMultiLinesPresenter.class.st
+++ b/src/Pyramid/PyramidColorInputMultiLinesPresenter.class.st
@@ -6,7 +6,7 @@ Class {
 		'colorInput',
 		'whenValueChangedDo'
 	],
-	#category : 'Pyramid-specs-custom'
+	#category : #'Pyramid-specs-custom'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidColorInputPresenter.class.st
+++ b/src/Pyramid/PyramidColorInputPresenter.class.st
@@ -7,7 +7,7 @@ Class {
 		'svMorph',
 		'whenValueChangedDo'
 	],
-	#category : 'Pyramid-specs-custom'
+	#category : #'Pyramid-specs-custom'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidColorInputSingleLineWithPickupButtonPresenter.class.st
+++ b/src/Pyramid/PyramidColorInputSingleLineWithPickupButtonPresenter.class.st
@@ -63,6 +63,7 @@ PyramidColorInputSingleLineWithPickupButtonPresenter >> openMultiLinesModal [
 	| dialog color window |
 	window := self multiLinesInput asModalWindow.
 	window title: 'Pickup a Color'.
+	window centered.
 	dialog := window open.
 	dialog isOk
 		ifTrue: [

--- a/src/Pyramid/PyramidCommand.class.st
+++ b/src/Pyramid/PyramidCommand.class.st
@@ -12,7 +12,7 @@ In some rare case, the method saveStatesOf: aCollection withCommand: aCommand wi
 Class {
 	#name : #PyramidCommand,
 	#superclass : #Object,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidCommandExecutor.class.st
+++ b/src/Pyramid/PyramidCommandExecutor.class.st
@@ -7,7 +7,7 @@ I’m an abstract class use to define the API.
 Class {
 	#name : #PyramidCommandExecutor,
 	#superclass : #Object,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidCommandExecutorDecorator.class.st
+++ b/src/Pyramid/PyramidCommandExecutorDecorator.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'wrappee'
 	],
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidCommandMemento.class.st
+++ b/src/Pyramid/PyramidCommandMemento.class.st
@@ -6,7 +6,7 @@ Class {
 		'target',
 		'arguments'
 	],
-	#category : 'Pyramid-history'
+	#category : #'Pyramid-history'
 }
 
 { #category : #visiting }

--- a/src/Pyramid/PyramidCompositeMemento.class.st
+++ b/src/Pyramid/PyramidCompositeMemento.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'mementos'
 	],
-	#category : 'Pyramid-history'
+	#category : #'Pyramid-history'
 }
 
 { #category : #visiting }

--- a/src/Pyramid/PyramidDynamicLayoutAllPanels.class.st
+++ b/src/Pyramid/PyramidDynamicLayoutAllPanels.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidDynamicLayoutAllPanels,
 	#superclass : #PyramidDynamicLayoutStrategy,
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidDynamicLayoutOnlyCenter.class.st
+++ b/src/Pyramid/PyramidDynamicLayoutOnlyCenter.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidDynamicLayoutOnlyCenter,
 	#superclass : #PyramidDynamicLayoutStrategy,
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidDynamicLayoutOnlyLeft.class.st
+++ b/src/Pyramid/PyramidDynamicLayoutOnlyLeft.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidDynamicLayoutOnlyLeft,
 	#superclass : #PyramidDynamicLayoutStrategy,
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidDynamicLayoutOnlyRight.class.st
+++ b/src/Pyramid/PyramidDynamicLayoutOnlyRight.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidDynamicLayoutOnlyRight,
 	#superclass : #PyramidDynamicLayoutStrategy,
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidDynamicLayoutStrategy.class.st
+++ b/src/Pyramid/PyramidDynamicLayoutStrategy.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidDynamicLayoutStrategy,
 	#superclass : #Object,
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidDynamicWindow.class.st
+++ b/src/Pyramid/PyramidDynamicWindow.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'layoutStrategy'
 	],
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidElementsChangedEvent.class.st
+++ b/src/Pyramid/PyramidElementsChangedEvent.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PyramidElementsChangedEvent,
 	#superclass : #PyramidProjectModelEvent,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }

--- a/src/Pyramid/PyramidEmptyValue.class.st
+++ b/src/Pyramid/PyramidEmptyValue.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidEmptyValue,
 	#superclass : #PyramidUnknowState,
-	#category : 'Pyramid-specs-custom'
+	#category : #'Pyramid-specs-custom'
 }
 
 { #category : #converting }

--- a/src/Pyramid/PyramidError.class.st
+++ b/src/Pyramid/PyramidError.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PyramidError,
 	#superclass : #Error,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }

--- a/src/Pyramid/PyramidEvent.class.st
+++ b/src/Pyramid/PyramidEvent.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PyramidEvent,
 	#superclass : #Announcement,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }

--- a/src/Pyramid/PyramidFirstLevelElementsChangedEvent.class.st
+++ b/src/Pyramid/PyramidFirstLevelElementsChangedEvent.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PyramidFirstLevelElementsChangedEvent,
 	#superclass : #PyramidProjectModelEvent,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }

--- a/src/Pyramid/PyramidHideEmptyPropertyStrategy.class.st
+++ b/src/Pyramid/PyramidHideEmptyPropertyStrategy.class.st
@@ -11,7 +11,7 @@ In other terms, any property who is not linked to any object in the collection w
 Class {
 	#name : #PyramidHideEmptyPropertyStrategy,
 	#superclass : #PyramidPresenterPropertiesStrategy,
-	#category : 'Pyramid-property'
+	#category : #'Pyramid-property'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidHistory.class.st
+++ b/src/Pyramid/PyramidHistory.class.st
@@ -5,7 +5,7 @@ Class {
 		'mementosStack',
 		'position'
 	],
-	#category : 'Pyramid-history'
+	#category : #'Pyramid-history'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidHistoryCommandExecutor.class.st
+++ b/src/Pyramid/PyramidHistoryCommandExecutor.class.st
@@ -8,7 +8,7 @@ Class {
 	#instVars : [
 		'history'
 	],
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidMagicButtonModel.class.st
+++ b/src/Pyramid/PyramidMagicButtonModel.class.st
@@ -9,7 +9,7 @@ Class {
 		'label',
 		'inputValidation'
 	],
-	#category : 'Pyramid-specs-custom'
+	#category : #'Pyramid-specs-custom'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidMainCommandExecutor.class.st
+++ b/src/Pyramid/PyramidMainCommandExecutor.class.st
@@ -5,7 +5,7 @@ I execute the command on the given targets with the given arguments.
 Class {
 	#name : #PyramidMainCommandExecutor,
 	#superclass : #PyramidCommandExecutor,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidMementoInverser.class.st
+++ b/src/Pyramid/PyramidMementoInverser.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidMementoInverser,
 	#superclass : #PyramidMementoVisitor,
-	#category : 'Pyramid-history'
+	#category : #'Pyramid-history'
 }
 
 { #category : #visiting }

--- a/src/Pyramid/PyramidMementoVisitor.class.st
+++ b/src/Pyramid/PyramidMementoVisitor.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidMementoVisitor,
 	#superclass : #Object,
-	#category : 'Pyramid-history'
+	#category : #'Pyramid-history'
 }
 
 { #category : #visiting }

--- a/src/Pyramid/PyramidMenuPanelBuilder.class.st
+++ b/src/Pyramid/PyramidMenuPanelBuilder.class.st
@@ -7,7 +7,7 @@ Class {
 		'multiGroups',
 		'singleGroups'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #adding }

--- a/src/Pyramid/PyramidMixedValues.class.st
+++ b/src/Pyramid/PyramidMixedValues.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidMixedValues,
 	#superclass : #PyramidUnknowState,
-	#category : 'Pyramid-specs-custom'
+	#category : #'Pyramid-specs-custom'
 }
 
 { #category : #converting }

--- a/src/Pyramid/PyramidMultiplePluginsFoundError.class.st
+++ b/src/Pyramid/PyramidMultiplePluginsFoundError.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'plugins'
 	],
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidNoPluginFoundError.class.st
+++ b/src/Pyramid/PyramidNoPluginFoundError.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'query'
 	],
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidNumberFilterOnlyDigitsInputPresenter.class.st
+++ b/src/Pyramid/PyramidNumberFilterOnlyDigitsInputPresenter.class.st
@@ -1,0 +1,91 @@
+Class {
+	#name : #PyramidNumberFilterOnlyDigitsInputPresenter,
+	#superclass : #PyramidInputPresenter,
+	#instVars : [
+		'inputNumber',
+		'submitBlock',
+		'defaultValue'
+	],
+	#category : #'Pyramid-specs-custom'
+}
+
+{ #category : #'as yet unclassified' }
+PyramidNumberFilterOnlyDigitsInputPresenter >> applyInputModel [
+
+	self inputNumber help: self inputModel help
+]
+
+{ #category : #layout }
+PyramidNumberFilterOnlyDigitsInputPresenter >> defaultLayout [
+
+	^ SpBoxLayout newHorizontal
+		  add: self inputNumber;
+		  yourself
+]
+
+{ #category : #accessing }
+PyramidNumberFilterOnlyDigitsInputPresenter >> defaultValue [
+
+	^ defaultValue
+]
+
+{ #category : #accessing }
+PyramidNumberFilterOnlyDigitsInputPresenter >> defaultValue: aValue [
+
+	defaultValue := aValue
+]
+
+{ #category : #'as yet unclassified' }
+PyramidNumberFilterOnlyDigitsInputPresenter >> getNumberFrom: aString [
+
+	^ NumberParser parse: aString onError: [ PyramidUnknowState new ]
+]
+
+{ #category : #initialization }
+PyramidNumberFilterOnlyDigitsInputPresenter >> initializePresenters [
+
+	| newText |
+	inputNumber := SpTextInputFieldPresenter new whenSubmitDo: [ :text |
+		               newText := text isEmpty
+			                          ifTrue: [ self defaultValue asString ]
+			                          ifFalse: [
+			                          AlbTextEditorDigitInputFilter new
+				                          filter: text ].
+		               newText value asNumber = 0 ifTrue: [
+			               newText := self defaultValue asString ].
+		               self submitBlock value: (self getNumberFrom: newText).
+		               self inputNumber text: newText ]
+]
+
+{ #category : #accessing }
+PyramidNumberFilterOnlyDigitsInputPresenter >> inputNumber [
+^ inputNumber
+]
+
+{ #category : #accessing }
+PyramidNumberFilterOnlyDigitsInputPresenter >> submitBlock [
+
+	submitBlock ifNil: [ submitBlock := [ :n | ] ].
+^ submitBlock
+]
+
+{ #category : #'as yet unclassified' }
+PyramidNumberFilterOnlyDigitsInputPresenter >> value [
+
+	^ self getNumberFrom: self inputNumber text
+]
+
+{ #category : #'as yet unclassified' }
+PyramidNumberFilterOnlyDigitsInputPresenter >> value: aNumber [
+
+	aNumber isNumber ifTrue: [
+		self inputNumber text: aNumber asFloat reduce printString.
+		^ self ].
+	self inputNumber text: '--'
+]
+
+{ #category : #'as yet unclassified' }
+PyramidNumberFilterOnlyDigitsInputPresenter >> whenValueChangedDo: aBlock [
+
+	submitBlock := aBlock
+]

--- a/src/Pyramid/PyramidNumberInputPresenter.class.st
+++ b/src/Pyramid/PyramidNumberInputPresenter.class.st
@@ -34,7 +34,8 @@ PyramidNumberInputPresenter >> getNumberFrom: aString [
 { #category : #'initialization - deprecated' }
 PyramidNumberInputPresenter >> initializePresenters [
 
-	inputNumber := SpTextInputFieldPresenter new whenSubmitDo: [ :text | 
+	inputNumber := SpTextInputFieldPresenter new
+							whenSubmitDo: [ :text | 
 								self submitBlock value: (self getNumberFrom: text); yourself ]
 ]
 

--- a/src/Pyramid/PyramidNumberInputPresenter.class.st
+++ b/src/Pyramid/PyramidNumberInputPresenter.class.st
@@ -34,8 +34,8 @@ PyramidNumberInputPresenter >> getNumberFrom: aString [
 { #category : #'initialization - deprecated' }
 PyramidNumberInputPresenter >> initializePresenters [
 
-	inputNumber := SpTextInputFieldPresenter new whenSubmitDo: [ :text |
-			               self submitBlock value: (self getNumberFrom: text) ]; yourself
+	inputNumber := SpTextInputFieldPresenter new whenSubmitDo: [ :text | 
+								self submitBlock value: (self getNumberFrom: text); yourself ]
 ]
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidPanelBuilder.class.st
+++ b/src/Pyramid/PyramidPanelBuilder.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidPanelBuilder,
 	#superclass : #Object,
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidPanelModel.class.st
+++ b/src/Pyramid/PyramidPanelModel.class.st
@@ -7,7 +7,7 @@ Class {
 		'window',
 		'presenter'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidPlaygroundView.class.st
+++ b/src/Pyramid/PyramidPlaygroundView.class.st
@@ -7,7 +7,7 @@ Class {
 		'codeObjectInteractionModel',
 		'contextLabel'
 	],
-	#category : 'Pyramid-plugin-playground'
+	#category : #'Pyramid-plugin-playground'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidPluginDynamicLayout.class.st
+++ b/src/Pyramid/PyramidPluginDynamicLayout.class.st
@@ -10,7 +10,7 @@ Class {
 		'isRightOpened',
 		'editorWindow'
 	],
-	#category : 'Pyramid-plugin-dynamic-layout'
+	#category : #'Pyramid-plugin-dynamic-layout'
 }
 
 { #category : #adding }

--- a/src/Pyramid/PyramidPluginManager.class.st
+++ b/src/Pyramid/PyramidPluginManager.class.st
@@ -7,7 +7,7 @@ Class {
 	#classInstVars : [
 		'uniqueInstance'
 	],
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }
 
 { #category : #'instance creation' }

--- a/src/Pyramid/PyramidPluginPlayground.class.st
+++ b/src/Pyramid/PyramidPluginPlayground.class.st
@@ -7,7 +7,7 @@ Class {
 		'activeProject',
 		'view'
 	],
-	#category : 'Pyramid-plugin-playground'
+	#category : #'Pyramid-plugin-playground'
 }
 
 { #category : #adding }

--- a/src/Pyramid/PyramidPopoverFactory.class.st
+++ b/src/Pyramid/PyramidPopoverFactory.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidPopoverFactory,
 	#superclass : #Object,
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidPresenterPanelBuilder.class.st
+++ b/src/Pyramid/PyramidPresenterPanelBuilder.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'item'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidPresenterPropertiesStrategy.class.st
+++ b/src/Pyramid/PyramidPresenterPropertiesStrategy.class.st
@@ -7,7 +7,7 @@ I do that with the message `#buildPresenterFromCollection:andManager:`
 Class {
 	#name : #PyramidPresenterPropertiesStrategy,
 	#superclass : #Object,
-	#category : 'Pyramid-property'
+	#category : #'Pyramid-property'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidProjectModelEvent.class.st
+++ b/src/Pyramid/PyramidProjectModelEvent.class.st
@@ -5,7 +5,7 @@ Class {
 		'selection',
 		'firstLevelElements'
 	],
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidPropertyNotInstalledError.class.st
+++ b/src/Pyramid/PyramidPropertyNotInstalledError.class.st
@@ -5,7 +5,7 @@ Class {
 		'manager',
 		'property'
 	],
-	#category : 'Pyramid-property'
+	#category : #'Pyramid-property'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidPropertyPresenterBuilder.class.st
+++ b/src/Pyramid/PyramidPropertyPresenterBuilder.class.st
@@ -9,7 +9,7 @@ Class {
 		'cluster',
 		'property'
 	],
-	#category : 'Pyramid-property'
+	#category : #'Pyramid-property'
 }
 
 { #category : #testing }

--- a/src/Pyramid/PyramidRemoveAllFromCollectionCommand.class.st
+++ b/src/Pyramid/PyramidRemoveAllFromCollectionCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidRemoveAllFromCollectionCommand,
 	#superclass : #PyramidCollectionCommand,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidRemoveFromCollectionCommand.class.st
+++ b/src/Pyramid/PyramidRemoveFromCollectionCommand.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidRemoveFromCollectionCommand,
 	#superclass : #PyramidCollectionCommand,
-	#category : 'Pyramid-commands'
+	#category : #'Pyramid-commands'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/PyramidSelectionChangedEvent.class.st
+++ b/src/Pyramid/PyramidSelectionChangedEvent.class.st
@@ -1,5 +1,5 @@
 Class {
 	#name : #PyramidSelectionChangedEvent,
 	#superclass : #PyramidProjectModelEvent,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }

--- a/src/Pyramid/PyramidSimpleWindow.class.st
+++ b/src/Pyramid/PyramidSimpleWindow.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidSimpleWindow,
 	#superclass : #PyramidWindow,
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #specs }

--- a/src/Pyramid/PyramidSortedCollectionWithCallbacks.class.st
+++ b/src/Pyramid/PyramidSortedCollectionWithCallbacks.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'sortFunction'
 	],
-	#category : 'Pyramid-models'
+	#category : #'Pyramid-models'
 }
 
 { #category : #signalling }

--- a/src/Pyramid/PyramidSpCodeObjectInteractionModel.class.st
+++ b/src/Pyramid/PyramidSpCodeObjectInteractionModel.class.st
@@ -4,7 +4,7 @@ Class {
 	#instVars : [
 		'projectModel'
 	],
-	#category : 'Pyramid-plugin-playground'
+	#category : #'Pyramid-plugin-playground'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidSpPresenter.class.st
+++ b/src/Pyramid/PyramidSpPresenter.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidSpPresenter,
 	#superclass : #SpPresenter,
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidTabItem.class.st
+++ b/src/Pyramid/PyramidTabItem.class.st
@@ -7,7 +7,7 @@ Class {
 		'label',
 		'icon'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #comparing }

--- a/src/Pyramid/PyramidTabPanelBuilder.class.st
+++ b/src/Pyramid/PyramidTabPanelBuilder.class.st
@@ -5,7 +5,7 @@ Class {
 		'presenter',
 		'item'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidToolbarItem.class.st
+++ b/src/Pyramid/PyramidToolbarItem.class.st
@@ -6,7 +6,7 @@ Class {
 		'constraints',
 		'order'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #comparing }

--- a/src/Pyramid/PyramidToolbarPanelBuilder.class.st
+++ b/src/Pyramid/PyramidToolbarPanelBuilder.class.st
@@ -5,7 +5,7 @@ Class {
 		'item',
 		'isHorizontal'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #accessing }

--- a/src/Pyramid/PyramidUnknowState.class.st
+++ b/src/Pyramid/PyramidUnknowState.class.st
@@ -1,7 +1,7 @@
 Class {
 	#name : #PyramidUnknowState,
 	#superclass : #Object,
-	#category : 'Pyramid-specs-custom'
+	#category : #'Pyramid-specs-custom'
 }
 
 { #category : #comparing }

--- a/src/Pyramid/PyramidWindow.class.st
+++ b/src/Pyramid/PyramidWindow.class.st
@@ -8,7 +8,7 @@ Class {
 		'spec',
 		'whenClosedDo'
 	],
-	#category : 'Pyramid-views'
+	#category : #'Pyramid-views'
 }
 
 { #category : #'window - properties' }

--- a/src/Pyramid/TPyramidFindPlugin.trait.st
+++ b/src/Pyramid/TPyramidFindPlugin.trait.st
@@ -1,6 +1,6 @@
 Trait {
 	#name : #TPyramidFindPlugin,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }
 
 { #category : #'as yet unclassified' }

--- a/src/Pyramid/TPyramidPlugin.trait.st
+++ b/src/Pyramid/TPyramidPlugin.trait.st
@@ -1,6 +1,6 @@
 Trait {
 	#name : #TPyramidPlugin,
-	#category : 'Pyramid-core'
+	#category : #'Pyramid-core'
 }
 
 { #category : #initialization }


### PR DESCRIPTION
The drag of selected element move on the line of grid, it's parametrable with the workplace properties pop-up (edit of old "window extent").

New "Workplace properties" UI : 
- Keep the "window extent" feature
- Grid visibility
- Spacing between each line
- Color of the grid

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

Default values :
- Size of the blue frame : 
      width -> 800
      height -> 600
- Grid visibility -> false
- Grid line spacing -> 10
- Grid color -> black

All values of the grid are editable. 

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  
 
Aspect of the "Workplace properties" UI : 
![{9D0CE9D5-4A66-49F7-B2B6-979B1868C9C3}](https://github.com/user-attachments/assets/295fddf0-bcaa-4d66-8a0e-658003366fc9)

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

Fix : 
- Correction of the bug pop-up grow each time we open it, only for "Workplace properties", the bug was already here with the "Window extent"