### PR TITLE
Adding shortcut manager feature to Pyramid for the moment focus on sp…

### DIFF
--- a/src/Pyramid-Bloc/PyramidShortcutCopyPaste.class.st
+++ b/src/Pyramid-Bloc/PyramidShortcutCopyPaste.class.st
@@ -1,0 +1,119 @@
+"
+This class is used to create the shortcut for copy and paste -> use the plugin-copy-paste from this package.
+
+It use the editor to get the collection of selected object from project model in Pyramid space.
+"
+Class {
+	#name : #PyramidShortcutCopyPaste,
+	#superclass : #PyramidSpaceShortcutManagerPlugin,
+	#instVars : [
+		'copyPastePlugin',
+		'shortcutCopy',
+		'shortcutPaste',
+		'keyCombinationCopy',
+		'keyCombinationPaste',
+		'elementCollectionSelected'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> copyPastePlugin: aPlugin [
+
+	copyPastePlugin := aPlugin
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutCopyPaste >> copyPastePluginFromPyramid: aPyramidEditor [
+
+	| copyPastePluginList |
+	self elementCollectionSelected: aPyramidEditor.
+	copyPastePluginList := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidCopyPastePlugin ].
+	copyPastePluginList size = 1
+	ifFalse: [^ self].
+	copyPastePlugin := copyPastePluginList asArray first
+]
+
+{ #category : #testing }
+PyramidShortcutCopyPaste >> copySelectedElementInSpace [
+
+	elementCollectionSelected isEmpty
+	ifTrue: [ ^ self ].
+	elementCollectionSelected size = 1
+	ifTrue: [ elementCollectionSelected do: [ :element | copyPastePlugin copyAsStonInClipboard: element ]. ]
+	ifFalse: [ self inform: 'Can not copy multiple element' ]
+	
+	
+	
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> defaultKeyCombinationCopy [
+	"CTRL + C to activate this shortcut"
+	keyCombinationCopy := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey C) build)
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> defaultKeyCombinationPaste [
+	"CTRL + V to activate this shortcut"
+	keyCombinationPaste := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey V) build)
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> elementCollectionSelected: aPyramidEditor [
+
+	elementCollectionSelected := (aPyramidEditor projectModel selection) collection.
+]
+
+{ #category : #initialization }
+PyramidShortcutCopyPaste >> initialize [ 
+
+	self defaultKeyCombinationCopy.
+	self defaultKeyCombinationPaste.
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> keyCombinationCopy: aKeyCombination [
+	
+	^ keyCombinationCopy := aKeyCombination
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> keyCombinationPaste: aKeyCombination [
+
+	^ keyCombinationPaste := aKeyCombination
+]
+
+{ #category : #testing }
+PyramidShortcutCopyPaste >> pasteElement [
+
+	elementCollectionSelected isEmpty
+	ifTrue: [ copyPastePlugin pasteFromClipboardOnFirstLevelElements ].
+	elementCollectionSelected size = 1
+	ifTrue: [ elementCollectionSelected do: [ :element | copyPastePlugin pasteFromClipboardOnSelection: element ]. ]
+	
+	
+	
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> shortcutActionCopy [
+
+	^ shortcutCopy := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut copy';
+			              combination: keyCombinationCopy;
+			              action: [ :event | copyPastePlugin 
+														ifNil: [ self inform: 'Plugin Copy/Paste is not installed' ]
+														ifNotNil: [ self copySelectedElementInSpace ] ]
+]
+
+{ #category : #accessing }
+PyramidShortcutCopyPaste >> shortcutActionPaste [
+
+	^ shortcutPaste := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut paste';
+			              combination: keyCombinationPaste;
+			              action: [ :event | copyPastePlugin
+														ifNil: [ self inform: 'Plugin Copy/Paste is not installed' ]
+														ifNotNil: [ self pasteElement ] ]
+]

--- a/src/Pyramid-Bloc/PyramidShortcutGrid.class.st
+++ b/src/Pyramid-Bloc/PyramidShortcutGrid.class.st
@@ -1,0 +1,63 @@
+"
+This class define the shortcut to show or hide the grid on the space.
+
+the grid is define in the plugin-space-extension -> PyramidMainExtension
+"
+Class {
+	#name : #PyramidShortcutGrid,
+	#superclass : #PyramidSpaceShortcutManagerPlugin,
+	#instVars : [
+		'gridFeature',
+		'shortcutGridVisibility',
+		'keyCombinationGridVisibility',
+		'keyCombinationTest',
+		'shortcutTest'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #accessing }
+PyramidShortcutGrid >> defaultKeyCombinationGridVisibility [
+	"CTRL + G to activate this shortcut"
+	keyCombinationGridVisibility := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey G) build)
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutGrid >> gridFeatureFromSpacePlugin: aPyramidEditor [
+
+	| spacePlugin spacePluginSet listOfSpaceExtension pyramidMainExtensionSet |
+	
+	spacePluginSet := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidSpacePlugin ].
+	spacePluginSet size = 1
+	ifFalse: [^ self].
+	spacePlugin := spacePluginSet asArray first.
+	
+	listOfSpaceExtension := spacePlugin builder extensions.
+	
+	pyramidMainExtensionSet := listOfSpaceExtension select: [ :extensions | extensions isKindOf: PyramidMainExtension ].
+	pyramidMainExtensionSet size = 1
+	ifFalse: [^ self].
+	gridFeature := pyramidMainExtensionSet asArray first
+	
+]
+
+{ #category : #initialization }
+PyramidShortcutGrid >> initialize [ 
+	
+	self defaultKeyCombinationGridVisibility.
+]
+
+{ #category : #accessing }
+PyramidShortcutGrid >> keyCombinationGridVisibility: aKeyCombination [
+	
+	keyCombinationGridVisibility := aKeyCombination
+]
+
+{ #category : #accessing }
+PyramidShortcutGrid >> shortcutActionGridVisibility [
+
+	^ shortcutGridVisibility := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut grid visibility';
+			              combination: keyCombinationGridVisibility;
+			              action: [ :event | 	gridFeature workplacePropertiesView visibilityButton toggleState ].
+]

--- a/src/Pyramid-Bloc/PyramidShortcutRemoveElement.class.st
+++ b/src/Pyramid-Bloc/PyramidShortcutRemoveElement.class.st
@@ -1,0 +1,53 @@
+"
+This class define the shortcut to delete a selected element in the space.
+
+it use the plugin-navigation in this package.
+"
+Class {
+	#name : #PyramidShortcutRemoveElement,
+	#superclass : #PyramidSpaceShortcutManagerPlugin,
+	#instVars : [
+		'navigationPlugin',
+		'shortcutActionRemoveElement',
+		'keyCombinationRemoveElement'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #accessing }
+PyramidShortcutRemoveElement >> defaultKeyCombinationRemoveElement [
+	"suppr / del to activate this shortcut"
+	keyCombinationRemoveElement := ((BlKeyCombination builder key: KeyboardKey delete) build)
+]
+
+{ #category : #initialization }
+PyramidShortcutRemoveElement >> initialize [ 
+	
+	self defaultKeyCombinationRemoveElement 
+]
+
+{ #category : #accessing }
+PyramidShortcutRemoveElement >> keyCombinationRemoveElement: aKeyCombination [
+	
+	keyCombinationRemoveElement := aKeyCombination
+]
+
+{ #category : #removing }
+PyramidShortcutRemoveElement >> navigationPluginForRemoveElementFromPyramid: aPyramidEditor [
+
+	| removeElementPluginList |
+	removeElementPluginList := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidNavigationPlugin ].
+	removeElementPluginList size = 1
+	ifFalse: [^ self].
+	navigationPlugin := removeElementPluginList asArray first
+]
+
+{ #category : #accessing }
+PyramidShortcutRemoveElement >> shortcutActionRemoveElement [
+
+	^ shortcutActionRemoveElement := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut remove selected element';
+			              combination: keyCombinationRemoveElement;
+			              action: [ :event | navigationPlugin ifNil: [ self inform: 'Plugin navigation is not installed' ]
+																			 ifNotNil: [ navigationPlugin removeSelectedElements ] ]
+]

--- a/src/Pyramid-Bloc/PyramidShortcutSave.class.st
+++ b/src/Pyramid-Bloc/PyramidShortcutSave.class.st
@@ -1,0 +1,54 @@
+"
+This class used to create shortcut for saving in Pyramid space.
+
+Used the plugin-save in this package.
+"
+Class {
+	#name : #PyramidShortcutSave,
+	#superclass : #PyramidSpaceShortcutManagerPlugin,
+	#instVars : [
+		'savePlugin',
+		'shortcutSave',
+		'keyCombinationSave'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #accessing }
+PyramidShortcutSave >> defaultKeyCombinationSave [
+	"CTRL + S to activate this shortcut"
+	keyCombinationSave := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey S) build)
+]
+
+{ #category : #initialization }
+PyramidShortcutSave >> initialize [ 
+	
+	self defaultKeyCombinationSave
+]
+
+{ #category : #accessing }
+PyramidShortcutSave >> keyCombinationSave: aKeyCombination [
+	
+	^ keyCombinationSave := aKeyCombination
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutSave >> savePluginFromPyramid: aPyramidEditor [
+
+	| savePluginList |
+	savePluginList := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidSavePlugin ].
+	savePluginList size = 1
+	ifFalse: [^ self].
+	savePlugin := savePluginList asArray first
+]
+
+{ #category : #accessing }
+PyramidShortcutSave >> shortcutActionSave [
+
+	^ shortcutSave := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut save';
+			              combination: keyCombinationSave;
+			              action: [ :event | savePlugin
+														ifNil: [ self inform: 'Plugin save is not installed' ]
+														ifNotNil: [ savePlugin saveAction ] ]
+]

--- a/src/Pyramid-Bloc/PyramidShortcutSelectAllElement.class.st
+++ b/src/Pyramid-Bloc/PyramidShortcutSelectAllElement.class.st
@@ -1,0 +1,65 @@
+"
+This class used to create shortcut for select all element or all children from one selected element in Pyramid space.
+"
+Class {
+	#name : #PyramidShortcutSelectAllElement,
+	#superclass : #PyramidSpaceShortcutManagerPlugin,
+	#instVars : [
+		'keyCombinationSelectAll',
+		'shortcutSelectAll',
+		'projectModel'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutSelectAllElement >> defaultKeyCombinationSelectAll [
+	"CTRL + A to activate this shortcut"
+	keyCombinationSelectAll := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey A) build)
+]
+
+{ #category : #initialization }
+PyramidShortcutSelectAllElement >> initialize [
+
+	self defaultKeyCombinationSelectAll 
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutSelectAllElement >> projectModelFromPyramid: aPyramidEditor [
+
+	projectModel := aPyramidEditor projectModel.
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutSelectAllElement >> selectAll [
+
+	projectModel selection asArray isEmpty
+		ifTrue: [ self selectAllElementInSpace ].
+	projectModel selection asArray size = 1
+		ifTrue: [ self selectAllChildrenOfSelectedElement ].
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutSelectAllElement >> selectAllChildrenOfSelectedElement [
+	
+	(projectModel selection collection asArray first) children isEmpty
+	ifTrue: [ self inform: 'No children to select in the selected element' ]
+	ifFalse: [ projectModel setSelection: (projectModel selection collection asArray first) children ]
+	
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutSelectAllElement >> selectAllElementInSpace [
+
+	projectModel setSelection: projectModel firstLevelElements collection
+]
+
+{ #category : #accessing }
+PyramidShortcutSelectAllElement >> shortcutActionSelectAll [
+
+	^ shortcutSelectAll := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut to select all element in space';
+			              combination: keyCombinationSelectAll;
+			              action: [ :event | projectModel ifNil: [ self inform: 'problem with the project model' ]
+																		ifNotNil: [  self selectAll ] ]
+]

--- a/src/Pyramid-Bloc/PyramidShortcutUndoRedo.class.st
+++ b/src/Pyramid-Bloc/PyramidShortcutUndoRedo.class.st
@@ -1,0 +1,82 @@
+"
+Class use to create the shortcut undo / redo.
+
+Use the history feature from the package Pyramid.
+"
+Class {
+	#name : #PyramidShortcutUndoRedo,
+	#superclass : #PyramidSpaceShortcutManagerPlugin,
+	#instVars : [
+		'historyPlugin',
+		'shortcutUndo',
+		'keyCombinationUndo',
+		'shortcutRedo',
+		'keyCombinationRedo'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #accessing }
+PyramidShortcutUndoRedo >> defaultKeyCombinationRedo [
+	"CTRL + Y to activate this shortcut"
+	keyCombinationRedo := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey Y) build)
+]
+
+{ #category : #accessing }
+PyramidShortcutUndoRedo >> defaultKeyCombinationUndo [
+	"CTRL + Z to activate this shortcut"
+	keyCombinationUndo := ((BlKeyCombination builder key: KeyboardKey controlLeft; key: KeyboardKey Z) build)
+]
+
+{ #category : #'as yet unclassified' }
+PyramidShortcutUndoRedo >> historyPluginFromPyramid: aPyramidEditor [
+
+	| historyPluginList |
+	historyPluginList := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidHistoryPlugin ].
+	historyPluginList size = 1
+	ifFalse: [^ self].
+	historyPlugin := historyPluginList asArray first. 
+]
+
+{ #category : #initialization }
+PyramidShortcutUndoRedo >> initialize [ 
+	
+	self defaultKeyCombinationRedo.
+	self defaultKeyCombinationUndo.
+]
+
+{ #category : #accessing }
+PyramidShortcutUndoRedo >> keyCombinationRedo: aNewKeyCombination [
+
+	^ keyCombinationRedo := aNewKeyCombination
+]
+
+{ #category : #accessing }
+PyramidShortcutUndoRedo >> keyCombinationUndo: aNewKeyCombination [
+
+	^ keyCombinationUndo := aNewKeyCombination
+]
+
+{ #category : #accessing }
+PyramidShortcutUndoRedo >> shortcutActionRedo [
+
+	^ shortcutRedo := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut redo';
+			              combination: keyCombinationRedo;
+			              action: [ :event | historyPlugin 
+														ifNil: [ self inform: 'Plugin undo/redo is not installed' ]
+														ifNotNil: [ historyPlugin history redo. 
+																		historyPlugin projectModel informElementsChanged ] ]
+]
+
+{ #category : #accessing }
+PyramidShortcutUndoRedo >> shortcutActionUndo [
+
+	^ shortcutUndo := BlShortcutWithAction new
+			              name: 'Pyramid edition shortcut undo';
+			              combination: keyCombinationUndo;
+			              action: [ :event | historyPlugin 
+														ifNil: [ self inform: 'Plugin undo/redo is not installed' ]
+														ifNotNil: [ historyPlugin history undo. 
+																		historyPlugin projectModel informElementsChanged ] ]
+]

--- a/src/Pyramid-Bloc/PyramidSpacePlugin.class.st
+++ b/src/Pyramid-Bloc/PyramidSpacePlugin.class.st
@@ -6,7 +6,8 @@ Class {
 	#instVars : [
 		'builder',
 		'morphicPresenter',
-		'resetSpaceButton'
+		'resetSpaceButton',
+		'resetBloc'
 	],
 	#category : #'Pyramid-Bloc-plugin-space'
 }
@@ -37,6 +38,7 @@ PyramidSpacePlugin >> connectOn: aPyramidEditor [
 { #category : #initialization }
 PyramidSpacePlugin >> initialize [
 	
+	resetBloc := [ :aSpace | ].
 	builder := PyramidSpaceBuilder defaultEditorBuilder.
 	morphicPresenter := SpMorphPresenter new.
 	resetSpaceButton := SpButtonPresenter new
@@ -74,12 +76,25 @@ PyramidSpacePlugin >> morphicPresenter [
 ^ morphicPresenter
 ]
 
+{ #category : #accessing }
+PyramidSpacePlugin >> resetBloc [
+
+	^ resetBloc
+]
+
+{ #category : #accessing }
+PyramidSpacePlugin >> resetBloc: aBlock [
+
+	resetBloc := aBlock
+]
+
 { #category : #initialization }
 PyramidSpacePlugin >> resetSpace [
 
 	| space |
 	space := self builder build.
 	self makePresenterWithBlSpace: space.
+	resetBloc value: space.
 	space show
 ]
 

--- a/src/Pyramid-Bloc/PyramidSpaceShortcutManagerPlugin.class.st
+++ b/src/Pyramid-Bloc/PyramidSpaceShortcutManagerPlugin.class.st
@@ -1,0 +1,132 @@
+"
+This class is use to add shortcut to the space in pyramid to use feature, you can check the PyramidShortcutUndoRedo as exemple.
+
+Shortcut only works when the space of Pyramid have the focus.
+
+List of current active shortcut (default value) :
+- Save -> ctrl + S
+- Undo -> ctrl + Z
+- Redo -> ctrl + Y
+- Copy -> ctrl + C
+- Paste -> ctrl + V
+- Grid visibility switch -> ctrl + G
+- Select all element -> ctrl + A
+- Delete selected element -> delete or suppr
+"
+Class {
+	#name : #PyramidSpaceShortcutManagerPlugin,
+	#superclass : #Object,
+	#traits : 'TPyramidPlugin',
+	#classTraits : 'TPyramidPlugin classTrait',
+	#instVars : [
+		'shortcutCollection',
+		'shortcutUndoRedo',
+		'shortcutCopyPaste',
+		'shortcutSaveAction',
+		'shortcutGrid',
+		'shortcutRemoveElement',
+		'shortcutSelectAllElement'
+	],
+	#category : #'Pyramid-Bloc-plugin-shortcut-manager'
+}
+
+{ #category : #adding }
+PyramidSpaceShortcutManagerPlugin >> addAllShortcutInCollection [
+	"Default values of the different shortcut"
+	
+	"Shortcut Undo (ctrl + Z) / Redo (ctrl + Y) "
+	shortcutCollection add: shortcutUndoRedo shortcutActionUndo. 
+	shortcutCollection add: shortcutUndoRedo shortcutActionRedo.
+	
+	"Shortcut Copy (ctrl + C) / Paste (ctrl + V)"
+	shortcutCollection add: shortcutCopyPaste shortcutActionCopy.
+	shortcutCollection add: shortcutCopyPaste shortcutActionPaste.
+	
+	"Shortcut Save (ctrl + S)"
+	shortcutCollection add: shortcutSaveAction shortcutActionSave.
+	
+	"Shortcut grid"
+	"Grid visibility (ctrl + G)"
+	shortcutCollection add: shortcutGrid shortcutActionGridVisibility.
+	
+	"Shortcut Remove Element (suppr / del)"
+	shortcutCollection add: shortcutRemoveElement shortcutActionRemoveElement.
+	
+	"Shortcut Select all element in space (ctrl + A)"
+	shortcutCollection add: shortcutSelectAllElement shortcutActionSelectAll.
+	
+	"New shortcut to add under this comment, keep the same patern as before"
+	
+]
+
+{ #category : #accessing }
+PyramidSpaceShortcutManagerPlugin >> addAllShortcutInSpace: aSpace [
+	
+	self addAllShortcutInCollection.
+	shortcutCollection do: [ :shortcut | aSpace root addShortcut: shortcut ].
+
+	
+]
+
+{ #category : #connecting }
+PyramidSpaceShortcutManagerPlugin >> connectOn: aPyramidEditor [
+
+	| spacePlugin spacePluginSet |
+	
+	"Get the space plugin to adding shortcut"
+	spacePluginSet := aPyramidEditor plugins select: [ :plugin | plugin isKindOf: PyramidSpacePlugin ].
+	spacePluginSet size = 1
+	ifFalse: [self inform: 'Space plugin is not installed -> impossible to install shortcut to the space'.
+				^ self].
+	spacePlugin := spacePluginSet asArray first.
+	
+	"Get History plugin for Undo / Redo shortcut"
+	shortcutUndoRedo historyPluginFromPyramid: aPyramidEditor.
+	
+	"Get Copy Paste plugin"
+	shortcutCopyPaste copyPastePluginFromPyramid: aPyramidEditor.
+	
+	"Get Save plugin"
+	shortcutSaveAction savePluginFromPyramid: aPyramidEditor.
+	
+	"Get space MainExtension"
+	shortcutGrid gridFeatureFromSpacePlugin: aPyramidEditor.
+	
+	"Get Navigation Plugin for shortcut remove element"
+	shortcutRemoveElement navigationPluginForRemoveElementFromPyramid: aPyramidEditor.
+	
+	shortcutSelectAllElement projectModelFromPyramid: aPyramidEditor.
+	
+	"Adding shortcut to Pyramid"
+	spacePlugin resetBloc: [ :aSpace | self refreshAllShortcutInSpace: aSpace ].
+	spacePlugin resetSpace.
+]
+
+{ #category : #initialization }
+PyramidSpaceShortcutManagerPlugin >> initialize [ 
+
+	shortcutCollection := OrderedCollection new.
+	
+	shortcutUndoRedo := PyramidShortcutUndoRedo new.
+	shortcutCopyPaste := PyramidShortcutCopyPaste new.
+	shortcutSaveAction := PyramidShortcutSave new.
+	shortcutGrid := PyramidShortcutGrid new.
+	shortcutRemoveElement := PyramidShortcutRemoveElement new.
+	shortcutSelectAllElement := PyramidShortcutSelectAllElement new.
+]
+
+{ #category : #'as yet unclassified' }
+PyramidSpaceShortcutManagerPlugin >> refreshAllShortcutInSpace: aSpace [
+	
+	self removeAllShortcutInSpace: aSpace.
+	self addAllShortcutInSpace: aSpace.
+	
+	
+]
+
+{ #category : #removing }
+PyramidSpaceShortcutManagerPlugin >> removeAllShortcutInSpace: aSpace [
+
+	shortcutCollection do: [ :shortcut | aSpace root removeShortcut: shortcut ].
+	shortcutCollection removeAll.
+]


### PR DESCRIPTION
…ace only.

List of current active shortcut (default value) :

•	Save -> ctrl left + S
•	Undo -> ctrl left + Z
•	Redo -> ctrl left + Y
•	Copy -> ctrl left + C
•	Paste -> ctrl left + V
•	Grid visibility switch -> ctrl left + G
•	Select all element -> ctrl left + A
•	Delete selected element -> delete or suppr

This shortcut need the focus on the space to works