### PR TITLE
Fix the Broken "play" Button 

### DIFF
--- a/src/Pyramid-Bloc/PyramidMainExtension.class.st
+++ b/src/Pyramid-Bloc/PyramidMainExtension.class.st
@@ -311,16 +311,17 @@ PyramidMainExtension >> initialize [
 		               constraintsDo: [ :c |
 			               c vertical matchParent.
 			               c horizontal matchParent ];
-		               zIndex: 0.
+		               zIndex: 2.
+		
+	borderElement addChild: gridElement.
 
 	sizeElement := BlElement new
 		               id: #MainExtension_sizeElement;
 		               extent: self defaultExtent;
 		               clipChildren: false;
 		               addChildren: {
-				               containerElement.
-				               borderElement.
-				               gridElement } yourself
+				               containerElement .
+				               borderElement } yourself
 ]
 
 { #category : #displaying }


### PR DESCRIPTION
Change the way the grid is added to the space, add to borderElement instead of sizeElement, can access to the interaction when the play button is on.

